### PR TITLE
Add support for delivering DSensorEvents to custom handler

### DIFF
--- a/dsensor/src/main/java/com/hoan/dsensor_master/DSensorEventProcessor.java
+++ b/dsensor/src/main/java/com/hoan/dsensor_master/DSensorEventProcessor.java
@@ -98,7 +98,7 @@ public class DSensorEventProcessor implements SensorEventListener {
     private final int mHasTypeLinearAcceleration;
 
     private final DSensorEventListener mDSensorEventListener;
-    private final Handler mUIHandler = new Handler(Looper.getMainLooper());
+    private final Handler mHandler;
 
     /**
      * Constructor.
@@ -116,9 +116,10 @@ public class DSensorEventProcessor implements SensorEventListener {
      * @param dSensorEventListener Callback for processed values
      */
     public DSensorEventProcessor(int dSensorTypes, int historyMaxLength, int hasTypeRotationVector, int hasTypeGravity,
-                                 int hasTypeLinearAcceleration, DSensorEventListener dSensorEventListener) {
+                                 int hasTypeLinearAcceleration, DSensorEventListener dSensorEventListener, Handler handler) {
         Logger.d(DSensorEventProcessor.class.getSimpleName(), "constructor(" + dSensorTypes + ", " + historyMaxLength
                 + ", " + hasTypeRotationVector + ", " + hasTypeGravity + ", " + hasTypeLinearAcceleration + ")");
+        mHandler = (handler != null) ? handler : new Handler(Looper.getMainLooper());
         mDSensorTypes = dSensorTypes;
         mDSensorEventListener = dSensorEventListener;
         mHasTypeRotationVector = hasTypeRotationVector;
@@ -235,7 +236,7 @@ public class DSensorEventProcessor implements SensorEventListener {
         }
 
         if (changedSensorTypes != 0) {
-            mUIHandler.post(new Runnable() {
+            mHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     mDSensorEventListener.onDSensorChanged(changedSensorTypes, builder.build());


### PR DESCRIPTION
Hi  @hoananguyen,

your library comes just handy for a project of mine, where I have been struggling to get reliable heading data if the device is not held horizontally :-)

Your library misses just a feature that I need. It always delivers DSensorEvent events to the main looper, while I need them delivered to my own thread for further processing.

This pull request does 2 things:
- it allows to send DSensorEvent events to a custom Handler
- if a custom Handler il provided, it also uses it for internal processing instead of creating a dedicated HandlerThread

It does so by offering a new startDProcessedSensor method with takes an additional Handler parameter. It is of course still perfectly possible to keep the old behavior by using one of the old startDProcessedSensor methods, or by passing a null Handler to the new methods.
